### PR TITLE
Parse additional items from history stream

### DIFF
--- a/examples/history/main.go
+++ b/examples/history/main.go
@@ -48,9 +48,12 @@ func main() {
 			fmt.Printf("Price: %f\n", *item.Price)
 
 			if *item.Type == "Ride" {
-				fmt.Printf("Time: %s\n", *item.Time)
+				fmt.Printf("Time: %s/Duration: %s\n", *item.Time, *item.Duration)
+				fmt.Printf("EndDate: %s\n", *item.EndDate)
 				fmt.Printf("StartBikeParkingNumber: %s\n", *item.StartBikeParkingNumber)
 				fmt.Printf("EndBikeParkingNumber: %s\n", *item.EndBikeParkingNumber)
+				fmt.Printf("BikeID: %s\n", *item.BikeID)
+				fmt.Printf("Distance: %d meters\n", *item.Distance)
 			}
 		}
 

--- a/velobike/history.go
+++ b/velobike/history.go
@@ -17,10 +17,15 @@ type HistoryItem struct {
 	Type                   *string  `json:"Type,omitempty"` // Possible types: "Ride", "Pay"
 	Price                  *float64 `json:"Price,omitempty"`
 	Rejected               *bool    `json:"Rejected,omitempty"`
-	StartDate              *string  `json:"StartDate,omitempty"`
+	StartDate              *string  `json:"StartDate,omitempty"`              // layout: 2006-01-02T15:04:05
 	StartBikeParkingNumber *string  `json:"StartBikeParkingNumber,omitempty"` // Only for type "Ride"
 	EndBikeParkingNumber   *string  `json:"EndBikeParkingNumber,omitempty"`   // Only for type "Ride"
 	Time                   *string  `json:"Time,omitempty"`                   // Only for type "Ride"
+	BikeID                 *string  `json:"BikeId,omitempty"`                 // Only for type "Ride"
+	EndDate                *string  `json:"EndDate,omitempty"`                // Only for type "Ride", layout: 2006-01-02T15:04:05
+	Distance               *int     `json:"CoveredDistance,omitempty"`        // Only for type "Ride", in meters
+	// Duration is always 5-10 seconds less than Time. I suspect it represents Time minus time needed to lock/unlock the bike.
+	Duration *string `json:"Duration"`
 }
 
 // Get returns user's history.


### PR DESCRIPTION
Parse additional items from the history stream to be able to calculate
statistics such as:
  - average distance per ride
  - the most popular bike id
  - average ride speed

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>