### PR TITLE
Fixes #8 update struct field names

### DIFF
--- a/examples/authorize/main.go
+++ b/examples/authorize/main.go
@@ -33,6 +33,6 @@ func main() {
 		return
 	}
 
-	client.SessionId = auth.SessionId
-	fmt.Printf("Session ID: %s\n", *client.SessionId)
+	client.SessionID = auth.SessionID
+	fmt.Printf("Session ID: %s\n", *client.SessionID)
 }

--- a/examples/favourite/main.go
+++ b/examples/favourite/main.go
@@ -34,7 +34,7 @@ func main() {
 		return
 	}
 
-	client.SessionId = auth.SessionId
+	client.SessionID = auth.SessionID
 
 	fmt.Printf("\nThe list of your favourite parkings:\n")
 

--- a/examples/history/main.go
+++ b/examples/history/main.go
@@ -33,7 +33,7 @@ func main() {
 		return
 	}
 
-	client.SessionId = auth.SessionId
+	client.SessionID = auth.SessionID
 
 	fmt.Printf("\nThe list of your velobike.ru events:\n")
 
@@ -44,7 +44,7 @@ func main() {
 	} else {
 		for _, item := range history.Items {
 			fmt.Printf("\nType: %s\n", *item.Type)
-			fmt.Printf("ID: %s\n", *item.Id)
+			fmt.Printf("ID: %s\n", *item.ID)
 			fmt.Printf("Date: %s\n", *item.StartDate)
 			fmt.Printf("Price: %f\n", *item.Price)
 			fmt.Printf("Rejected: %v\n", *item.Rejected)

--- a/examples/parkings/main.go
+++ b/examples/parkings/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/rumyantseva/go-velobike/velobike"
 )
 

--- a/examples/profile/main.go
+++ b/examples/profile/main.go
@@ -34,15 +34,15 @@ func main() {
 		return
 	}
 
-	client.SessionId = auth.SessionId
+	client.SessionID = auth.SessionID
 
-	// If we set client.SessionId we can use "only authorized" methods:
+	// If we set client.SessionID we can use "only authorized" methods:
 	profile, _, err := client.Profile.Get()
 
 	if err != nil {
 		fmt.Printf("error: %v\n\n", err)
 	} else {
-		fmt.Printf("\nUser ID: %s\n", *profile.UserId)
+		fmt.Printf("\nUser ID: %s\n", *profile.UserID)
 		fmt.Printf("Email: %s\n", *profile.Email)
 	}
 }


### PR DESCRIPTION
Following the fix for #2 the examples no longer compile. This fix updates the references to struct fields to ensure they use the correct case. All examples should now compile and run.