### PR TITLE
Add a now-must-include App-Version header

### DIFF
--- a/velobike/velobike.go
+++ b/velobike/velobike.go
@@ -74,6 +74,8 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
+	req.Header.Add("App-Version", "1.3")
+
 	if c.SessionID != nil {
 		req.Header.Add("SessionID", *c.SessionID)
 	}


### PR DESCRIPTION
The Velobike API now returns an error without this header complaining about an old version of the users's application.
The App-Version is set to 1.3.