### PR TITLE
Add checking a response for errors

### DIFF
--- a/velobike/velobike.go
+++ b/velobike/velobike.go
@@ -122,7 +122,10 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {
-			io.Copy(w, &buf)
+			_, err = io.Copy(w, &buf)
+			if err != nil {
+				return response, err
+			}
 		} else {
 			err = json.NewDecoder(&buf).Decode(v)
 			if err == io.EOF {

--- a/velobike/velobike.go
+++ b/velobike/velobike.go
@@ -74,6 +74,8 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
+	req.Header.Add("App-Version", "1.3")
+
 	if c.SessionID != nil {
 		req.Header.Add("SessionID", *c.SessionID)
 	}


### PR DESCRIPTION
Velobike API lacks proper error handling with HTTP status codes so we
are forced to try to unmarshal a JSON document to the new `ErrorResponse` struct, which implements `error` interface and, if succeeded, `CheckError` function returns it to a caller.