### PR TITLE
Modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rumyantseva/go-velobike/v3
+
+require golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480 h1:O5YqonU5IWby+w98jVUG9h7zlCWCcH4RHyPVReBmhzk=
+golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Added basic `go.mod` and `go.sum` for the latest v3 repo tag.
Examples should reflect this change in their import statements, but I'm afraid it will break examples for someone how doesn't keep up with go modules.
